### PR TITLE
Fix deprecated libav function on MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,19 @@ Compile the source code using this command (all one line):
 
     g++ -o untrunc file.cpp main.cpp track.cpp atom.cpp mp4.cpp -L/usr/local/lib -lavformat -lavcodec -lavutil
 
+## Installing on Mac
+
+Download the source code from GitHub at https://github.com/ponchio/untrunc and unzip the source code.
+
+    cd untrunc-master
+
+Install libav using homebrew
+
+    brew install libav
+
+Build untrunc
+
+    g++ -o untrunc file.cpp main.cpp track.cpp atom.cpp mp4.cpp -L/usr/local/lib -lavformat -lavcodec -lavutil
 
 ## Installing on other operating system (Manual libav installation)
 

--- a/track.cpp
+++ b/track.cpp
@@ -201,7 +201,7 @@ bool Codec::matchSample(unsigned char *start, int maxlength) {
 
 int Codec::getLength(unsigned char *start, int maxlength) {
 	if(name == "mp4a") {
-		AVFrame *frame = avcodec_alloc_frame();
+		AVFrame *frame = av_frame_alloc();
 		if(!frame)
 			throw string("Could not create AVFrame");
 		AVPacket avp;
@@ -217,7 +217,7 @@ int Codec::getLength(unsigned char *start, int maxlength) {
 	} else if(name == "mp4v") {
 
 		/*     THIS DOES NOT SEEM TO WORK FOR SOME UNKNOWN REASON. IT JUST CONSUMES ALL BYTES.
-  *     AVFrame *frame = avcodec_alloc_frame();
+  *     AVFrame *frame = av_frame_alloc();
 		if(!frame)
 			throw string("Could not create AVFrame");
 		AVPacket avp;


### PR DESCRIPTION
Libav[1] has change the function avcodec_alloc_frame to av_frame_alloc.
This fix is required to build untrunc with latest libav

[1]https://patches.libav.org/patch/44214/
